### PR TITLE
Add non-null check before accessing pointer (#83459)

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -6,9 +6,9 @@ on:
   # https://github.com/intel/llvm/settings/actions for security.
   pull_request:
     branches:
-    - sycl
-    - sycl-devops-pr/**
-    - sycl-rel-**
+    - 'sycl'
+    - 'sycl-devops-pr/**'
+    - 'sycl-rel-**'
     # Do not run builds if changes are only in the following locations
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1054,6 +1054,7 @@ void SIFoldOperands::foldOperand(
       // Don't fold if OpToFold doesn't hold an aligned register.
       const TargetRegisterClass *RC =
           TRI->getRegClassForReg(*MRI, OpToFold.getReg());
+      assert(RC);
       if (TRI->hasVectorRegisters(RC) && OpToFold.getSubReg()) {
         unsigned SubReg = OpToFold.getSubReg();
         if (const TargetRegisterClass *SubRC =


### PR DESCRIPTION
Add a check if RC is not null to ensure that a consecutive access is safe.

A static analyzer flagged this issue since hasVectorRegisters potentially dereferences RC.